### PR TITLE
Fix initial slider sync

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -118,8 +118,8 @@ const slider = {
     const predictedValue = slider.predictNextValue();
     if (predictedValue !== null) {
       dom.slider.value = predictedValue;
-      slider.updateTooltip();
     }
+    slider.updateTooltip();
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure the search engine slider initializes button color and tooltip

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683f4ca3049c832ab34c91e1cc795a44