### PR TITLE
Refine logo styling (reduce glow, subtle gradient, align font)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -49,26 +49,24 @@ main {
   =========================== */
 .logo {
   font-size: 2.5em;
-  font-weight: bold;
-  text-shadow: 0 4px 6px rgba(0,0,0,0.3), 0 0 15px rgba(72,157,241,0.5);
-  background: linear-gradient(90deg, #4caf50, #2563eb);
+  font-weight: 600;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.25);
+  background: linear-gradient(90deg, #93c5fd, #60a5fa);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
   text-align: center;
-  animation: glow 2s infinite;
+  animation: glow 6s ease-in-out infinite;
   user-select: none;
   margin-bottom: 25px;
-  will-change: text-shadow;
-  font-family: sans-serif;
 }
 
 @keyframes glow {
   0%, 100% {
-   text-shadow: 0 0 5px rgba(72,157,241,0.5), 0 0 10px rgba(76,175,80,0.7);
+   text-shadow: 0 2px 4px rgba(0,0,0,0.2), 0 0 6px rgba(96,165,250,0.35);
   }
   50% {
-   text-shadow: 0 0 15px rgba(72,157,241,0.8), 0 0 20px rgba(76,175,80,1);
+   text-shadow: 0 2px 6px rgba(0,0,0,0.25), 0 0 10px rgba(96,165,250,0.45);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Soften an overly-strong animated glow and heavy text-shadow on the page title to improve visual consistency with the UI.
- Replace the high-contrast multi-color gradient with a more subtle two-tone brand color and normalize font-weight to match global typography.

### Description
- Updated `assets/css/style.css` to reduce text-shadow intensity and shorten shadow spread for `.logo`.
- Replaced the previous green/blue gradient with a subtler blue two-tone gradient and set `font-weight` to `600` for the logo.
- Slowed and eased the `glow` animation to `6s ease-in-out` and adjusted `@keyframes glow` to apply a lighter, less saturated halo.
- Removed the logo-specific `font-family: sans-serif` override so the global `Poppins` stack in `body` is preserved.

### Testing
- Served the site locally with `python -m http.server 8000` and ran a Playwright script to load the page and capture a screenshot, which completed successfully and produced `artifacts/logo-update.png`.
- No unit or CI tests were required for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884e719998832a8fd9199bc22ed176)