### PR TITLE
Use CSS palette variables for search UI and unify slider/button gradient

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,6 +24,18 @@ body {
   overscroll-behavior: none;
 }
 
+:root {
+  --brand-primary: #4caf50;
+  --brand-accent: #2563eb;
+  --surface: rgba(255,255,255,0.05);
+  --surface-border: rgba(255,255,255,0.2);
+  --surface-strong: rgba(255,255,255,0.1);
+  --surface-strong-hover: rgba(255,255,255,0.15);
+  --brand-glow: rgba(76,175,80,0.7);
+  --brand-glow-soft: rgba(76,175,80,0.2);
+  --brand-glow-strong: rgba(76,175,80,0.3);
+}
+
 /* Dark Mode */
 body.dark {
   background: linear-gradient(135deg, #1f1f1f, #1a1a1a);
@@ -82,9 +94,9 @@ main {
   flex-direction: column;
   align-items: center;
   margin: 0 auto;
-  background: rgba(255,255,255,0.05);
+  background: var(--surface);
   backdrop-filter: blur(8px);
-  border: 1px solid rgba(255,255,255,0.2);
+  border: 1px solid var(--surface-border);
   border-radius: 16px;
   padding: 24px;
   transition: transform 0.3s;
@@ -108,7 +120,7 @@ main {
   border: none;
   border-radius: 50px;
   outline: none;
-  background: rgba(255,255,255,0.1);
+  background: var(--surface-strong);
   color: #fff;
   box-shadow: inset 0 2px 5px rgba(0,0,0,0.2), 0 0 10px rgba(255,255,255,0.2);
   transition: background-color 0.3s, box-shadow 0.3s;
@@ -116,7 +128,7 @@ main {
 }
 
 #inputbox:focus {
-  background: rgba(255,255,255,0.15);
+  background: var(--surface-strong-hover);
   box-shadow: 0 0 15px rgba(255,255,255,0.6);
 }
 
@@ -220,7 +232,7 @@ main {
   appearance: none;
   width: 100%;
   height: 12px;
-  background: linear-gradient(90deg, #2563eb, #4caf50, #e11d48);
+  background: linear-gradient(90deg, var(--brand-primary), var(--brand-accent));
   border-radius: 10px;
   outline: none;
   transition: opacity 0.2s, background 0.3s, box-shadow 0.3s;
@@ -230,7 +242,7 @@ main {
 }
 
 .slider:hover {
-  box-shadow: 0 0 10px rgba(255,255,255,0.3);
+  box-shadow: 0 0 10px var(--brand-glow);
 }
 
 .slider::-webkit-slider-thumb {
@@ -241,13 +253,13 @@ main {
   background: #fff;
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 0 0 4px rgba(76,175,80,0.2);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 0 0 4px var(--brand-glow-soft);
   transition: box-shadow 0.3s, transform 0.2s;
-  border: 2px solid #4caf50;
+  border: 2px solid var(--brand-primary);
 }
 
 .slider::-webkit-slider-thumb:hover {
-  box-shadow: 0 4px 8px rgba(0,0,0,0.4), 0 0 0 6px rgba(76,175,80,0.3);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.4), 0 0 0 6px var(--brand-glow-strong);
   transform: scale(1.1);
 }
 
@@ -257,20 +269,20 @@ main {
   background: #fff;
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 0 0 4px rgba(76,175,80,0.2);
-  border: 2px solid #4caf50;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 0 0 4px var(--brand-glow-soft);
+  border: 2px solid var(--brand-primary);
   transition: box-shadow 0.3s, transform 0.2s;
 }
 
 .slider::-moz-range-thumb:hover {
-  box-shadow: 0 4px 8px rgba(0,0,0,0.4), 0 0 0 6px rgba(76,175,80,0.3);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.4), 0 0 0 6px var(--brand-glow-strong);
   transform: scale(1.1);
 }
 
 .slider::-moz-range-track {
   width: 100%;
   height: 12px;
-  background: linear-gradient(90deg, #2563eb, #4caf50, #e11d48);
+  background: linear-gradient(90deg, var(--brand-primary), var(--brand-accent));
   border-radius: 10px;
 }
 
@@ -281,7 +293,7 @@ main {
   padding: 12px 30px;
   font-size: 18px;
   color: #fff;
-  background-color: var(--btn-color, #4caf50);
+  background: linear-gradient(90deg, var(--brand-primary), var(--brand-accent));
   border: none;
   border-radius: 50px;
   cursor: pointer;
@@ -292,7 +304,7 @@ main {
 
 #searchBtn:hover {
   transform: scale(1.05);
-  box-shadow: 0 0 15px var(--btn-hover-color, rgba(76,175,80,0.7));
+  box-shadow: 0 0 15px var(--brand-glow);
 }
 
 /* ===========================


### PR DESCRIPTION
### Motivation
- Introduce a small, centralized design token set to make the search UI palette easier to maintain and theme. 
- Replace hard-coded colors in the search container, input, slider, and button so they share a consistent brand look.

### Description
- Added `:root` CSS custom properties (e.g., `--brand-primary`, `--brand-accent`, `--surface`, `--surface-border`, glow tokens) to `assets/css/style.css`.
- Updated `.search-container` to use `--surface` and `--surface-border` for background and border.
- Updated `#inputbox` to use `--surface-strong` / `--surface-strong-hover` for base and focus backgrounds.
- Simplified `.slider` gradient to a single `primary -> accent` blend and switched slider thumb, track, hover, and shadow colors to the new variables.
- Replaced the previous button color with a matching `linear-gradient(90deg, var(--brand-primary), var(--brand-accent))` and updated the hover glow to use the brand glow variable.

### Testing
- Started a local static server with `python -m http.server 8000` and ran a Playwright script that loaded `index.html` and captured a screenshot, which completed successfully and produced `artifacts/search-ui.png`.
- No unit tests were changed since this is a static CSS update and the automated smoke-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884e720704832ab163f60afec9b069)