### PR TITLE
Improve focus styles and accessibility for interactive controls

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -431,20 +431,20 @@ body.dark .dark-mode-toggle .toggle-icon {
   outline-offset: 2px;
 }
 
-.dark-mode-toggle:focus,
-.dark-mode-toggle:active,
-.mic-icon:focus,
-.mic-icon:active,
-.slider-container:focus,
-.slider-container:active,
-.slider:focus,
-.slider:active,
-.tooltip:focus,
-.tooltip:active {
-  outline: none !important;
-  outline-offset: 0 !important;
-  box-shadow: none !important;
-  -webkit-tap-highlight-color: transparent !important;
+:root {
+  --focus-ring-color: #4caf50;
+  --focus-ring-shadow: rgba(76,175,80,0.35);
+}
+
+.dark-mode-toggle:focus-visible,
+.mic-icon:focus-visible,
+#searchBtn:focus-visible,
+.slider:focus-visible,
+.search-history li:focus-visible,
+.search-history-list li:focus-visible {
+  outline: 2px solid var(--focus-ring-color);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 3px var(--focus-ring-shadow);
 }
 
 .logo,


### PR DESCRIPTION
### Motivation
- Remove existing rules that suppressed focus outlines and box-shadows so keyboard and assistive users can see focus state. 
- Provide a consistent, visible focus style across primary interactive elements to improve accessibility and visual consistency.

### Description
- Removed the broad focus/active rule that reset `outline` and `box-shadow` for `.dark-mode-toggle`, `.mic-icon`, `.slider`, `.tooltip`, and related selectors. 
- Added `:root` CSS variables `--focus-ring-color` and `--focus-ring-shadow` for a shared focus style token. 
- Applied a consistent `:focus-visible` rule that sets a `2px` outline, `3px` offset, and a subtle outer shadow to `.dark-mode-toggle`, `.mic-icon`, `#searchBtn`, `.slider`, and `.search-history` list items. 
- Kept existing general `:focus` fallback but scoped the new visible ring to `:focus-visible` to avoid visual noise on mouse interaction.

### Testing
- Started a local static server with `python -m http.server 8000` and validated the UI by capturing a screenshot with a Playwright script, which completed successfully and produced `artifacts/focus-styles.png`.
- Verified the CSS change via `git diff` and committed the updated `assets/css/style.css` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884e73e6e0832a9fbf86cb960ae0a2)